### PR TITLE
Set admin password during install

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ For more documentation about PeachPub, visit https://docs.peachcloud.org.
 - Invite creation 
 - Update pub profile and description
 
-**Shipped version:** 0.6.19~ynh4
+**Shipped version:** 0.6.19~ynh6
 
 **Demo:** https://demo.peachcloud.org
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -27,7 +27,7 @@ For more documentation about PeachPub, visit https://docs.peachcloud.org.
 - Invite creation 
 - Update pub profile and description
 
-**Version incluse :** 0.6.19~ynh4
+**Version incluse :** 0.6.19~ynh6
 
 **Démo :** https://demo.peachcloud.org
 

--- a/manifest.json
+++ b/manifest.json
@@ -5,7 +5,7 @@
     "description": {
         "en": "Secure Scuttlebutt pub with a web interface for pub management."
     },
-    "version": "0.6.19~ynh5",
+    "version": "0.6.19~ynh6",
     "url": "https://docs.peachcloud.org",
     "upstream": {
         "license": "AGPL-3.0",

--- a/scripts/install
+++ b/scripts/install
@@ -159,6 +159,13 @@ mkdir -p /etc/sudoers.d/
 ynh_add_config --template="sudoers" --destination="/etc/sudoers.d/$app"
 
 #=================================================
+# CONFIGURE ADMIN PASSWORD
+#=================================================
+ynh_script_progression --message="Configuring admin password" --weight=1
+escaped_password=$(printf "%q" $password)
+PEACH_CONFIG_PATH=$datadir/config/config.yml $final_path/peach-config changepassword -p $escaped_password
+
+#=================================================
 # SETUP SYSTEMD
 #=================================================
 ynh_script_progression --message="Configuring a systemd service..."  --weight=1


### PR DESCRIPTION
Before the admin password was being left as the default.

This PR sets the admin password based on the value passed during installation. 