### PR TITLE
Fix /etc/suduoers.d/peachpub

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ For more documentation about PeachPub, visit https://docs.peachcloud.org.
 - Invite creation 
 - Update pub profile and description
 
-**Shipped version:** 0.6.19~ynh10
+**Shipped version:** 0.6.19~ynh11
 
 **Demo:** https://demo.peachcloud.org
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -27,7 +27,7 @@ For more documentation about PeachPub, visit https://docs.peachcloud.org.
 - Invite creation 
 - Update pub profile and description
 
-**Version incluse :** 0.6.19~ynh10
+**Version incluse :** 0.6.19~ynh11
 
 **Démo :** https://demo.peachcloud.org
 

--- a/conf/sudoers
+++ b/conf/sudoers
@@ -1,1 +1,2 @@
 __APP__ ALL=(ALL) NOPASSWD: /usr/bin/systemctl start __GO_SBOT_SERVICE__, /usr/bin/systemctl stop __GO_SBOT_SERVICE__, /usr/bin/systemctl restart __GO_SBOT_SERVICE__, /usr/bin/systemctl enable __GO_SBOT_SERVICE__, /usr/bin/systemctl disable __GO_SBOT_SERVICE__
+

--- a/manifest.json
+++ b/manifest.json
@@ -5,7 +5,7 @@
     "description": {
         "en": "Secure Scuttlebutt pub with a web interface for pub management."
     },
-    "version": "0.6.19~ynh9",
+    "version": "0.6.19~ynh10",
     "url": "https://www.peachcloud.org",
     "upstream": {
         "license": "AGPL-3.0",

--- a/manifest.json
+++ b/manifest.json
@@ -5,7 +5,7 @@
     "description": {
         "en": "Secure Scuttlebutt pub with a web interface for pub management."
     },
-    "version": "0.6.19~ynh10",
+    "version": "0.6.19~ynh11",
     "url": "https://www.peachcloud.org",
     "upstream": {
         "license": "AGPL-3.0",

--- a/scripts/change_url
+++ b/scripts/change_url
@@ -133,8 +133,8 @@ start_systemd_services $app
 
 # publish new domain with the sbot, once the services are running again
 ynh_script_progression --message="Publishing new domain with sbot..."  --weight=1
-PEACH_CONFIG_PATH=$datadir/config/config.yml $final_path/peach-config wait-for-sbot
-PEACH_CONFIG_PATH=$datadir/config/config.yml $final_path/peach-config publish-address -a $new_domain:$ssbport
+ynh_exec_as $app PEACH_CONFIG_PATH=$datadir/config/config.yml $final_path/peach-config wait-for-sbot
+ynh_exec_as $app PEACH_CONFIG_PATH=$datadir/config/config.yml $final_path/peach-config publish-address -a $new_domain:$ssbport
 
 #=================================================
 # RELOAD NGINX

--- a/scripts/install
+++ b/scripts/install
@@ -150,6 +150,8 @@ chown $app:$app "$datadir/config/config.yml"
 
 mkdir -p /etc/sudoers.d/
 ynh_add_config --template="sudoers" --destination="/etc/sudoers.d/$app"
+chown root:root /etc/sudoers.d/$app
+chmod 440 /etc/sudoers.d/$app
 
 #=================================================
 # CONFIGURE ADMIN PASSWORD

--- a/scripts/install
+++ b/scripts/install
@@ -157,7 +157,7 @@ ynh_add_config --template="sudoers" --destination="/etc/sudoers.d/$app"
 ynh_script_progression --message="Configuring admin password" --weight=1
 
 escaped_password=$(printf "%q" $password)
-PEACH_CONFIG_PATH=$datadir/config/config.yml $final_path/peach-config change-password -p $escaped_password
+ynh_exec_as $app PEACH_CONFIG_PATH=$datadir/config/config.yml $final_path/peach-config change-password -p $escaped_password
 
 #=================================================
 # SETUP SYSTEMD
@@ -199,8 +199,8 @@ start_systemd_services $app
 #=================================================
 # CONFIGURE DOMAIN AFTER SBOT IS RUNNING
 #=================================================
-PEACH_CONFIG_PATH=$datadir/config/config.yml $final_path/peach-config wait-for-sbot
-PEACH_CONFIG_PATH=$datadir/config/config.yml $final_path/peach-config publish-address -a $domain:$ssbport
+ynh_exec_as $app PEACH_CONFIG_PATH=$datadir/config/config.yml $final_path/peach-config wait-for-sbot
+ynh_exec_as $app PEACH_CONFIG_PATH=$datadir/config/config.yml $final_path/peach-config publish-address -a $domain:$ssbport
 
 #=================================================
 # SETUP SSOWAT

--- a/scripts/install
+++ b/scripts/install
@@ -148,6 +148,7 @@ ynh_add_config --template="peach.yml" --destination="$datadir/config/config.yml"
 chmod 600 "$datadir/config/config.yml"
 chown $app:$app "$datadir/config/config.yml"
 
+ynh_script_progression --message="Creating /etc/sudoers.d/$app" --weight=1
 mkdir -p /etc/sudoers.d/
 ynh_add_config --template="sudoers" --destination="/etc/sudoers.d/$app"
 chown root:root /etc/sudoers.d/$app

--- a/scripts/restore
+++ b/scripts/restore
@@ -107,6 +107,8 @@ ynh_exec_warn_less yunohost firewall allow --no-upnp TCP $ssbport
 ynh_script_progression --message="Restoring various files..." --weight=1
 
 ynh_restore_file --origin_path="/etc/sudoers.d/$app"
+chown root:root /etc/sudoers.d/$app
+chmod 440 /etc/sudoers.d/$app
 
 #=================================================
 # RESTORE SYSTEMD


### PR DESCRIPTION
I was seeing some warnings before about /etc/suduoers.d/peachpub having the wrong permissions, and sometimes it was not parsed correctly (I believe because there was no newline at the end of the file).

This PR fixes both of those issues. 